### PR TITLE
Releasing from any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - release/*
   pull_request:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,13 @@
-name: Release a new version from master
+name: Release a new version
 
 on: 
   workflow_dispatch:
     inputs:
       version:
         description: 'Version of the library'
+        required: true
+      confirmBranch:
+        description: 'Confirm release branch'
         required: true
       command:
         description: 'Library deploy command'
@@ -18,9 +21,9 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
-      - name: Make sure we're on master branch
+      - name: Make sure we're on the proper branch
         run: |
-          [[ $GITHUB_REF == "refs/heads/master" ]] || exit 1
+          [[ $GITHUB_REF == refs/heads/${{ github.event.inputs.confirmBranch }} ]] || exit 1
       - name: Force Xcode 11.4
         run: sudo xcode-select -switch /Applications/Xcode_11.4.app
       - name: Publish the library

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - release/*
   pull_request:
 
 jobs:


### PR DESCRIPTION
This resolves #51.

The "publish script" can now release from any branch (to support the Wultra versioning/branching scheme).