### PR TITLE
Removed currentServerDate in favour of powerAuthSDK timeService

### DIFF
--- a/WultraMobileTokenSDK/Operations/Service/WMTOperationsImpl.swift
+++ b/WultraMobileTokenSDK/Operations/Service/WMTOperationsImpl.swift
@@ -118,13 +118,12 @@ class WMTOperationsImpl<T: WMTUserOperation>: WMTOperations, WMTService {
         set { networking.acceptLanguage = newValue }
     }
     
-    /// Calculated difference between server and device time
-    private var serverDateShiftInSeconds: TimeInterval?
-    var currentServerDate: Date? {
-        if let serverDateShiftInSeconds {
-            return Date().addingTimeInterval(serverDateShiftInSeconds)
+    private var currentDate: Date {
+        let timeService = powerAuth.timeSynchronizationService
+        if timeService.isTimeSynchronized {
+            return Date(timeIntervalSince1970: timeService.currentTime())
         }
-        return nil
+        return Date()
     }
     
     private var tasks = [GetOperationsTask]() // Task that are waiting for operation fetch
@@ -282,8 +281,7 @@ class WMTOperationsImpl<T: WMTUserOperation>: WMTOperations, WMTService {
         guard validateActivation(completion) else {
             return nil
         }
-        
-        let data = WMTAuthorizationData(operation: operation, timestampSent: currentServerDate ?? Date())
+        let data = WMTAuthorizationData(operation: operation, timestampSent: currentDate)
         
         return networking.post(data: .init(data), signedWith: authentication, to: WMTOperationEndpoints.Authorize.endpoint) { response, error in
             self.processResult(response: response, error: error) { result in
@@ -403,11 +401,7 @@ class WMTOperationsImpl<T: WMTUserOperation>: WMTOperations, WMTService {
         networking.post(data: .init(), signedWith: .possession(), to: WMTOperationEndpoints.List<T>.endpoint) { response, error in
             
             assert(Thread.isMainThread)
-            
-            if let response {
-                self.processServerTime(response: response, requestStarted: requestStartDate)
-            }
-            
+
             // if all tasks were canceled, just ignore the result.
             guard self.tasks.contains(where: { $0.isCanceled == false }) else {
                 completion(.failure(WMTError(reason: .unknown)))
@@ -428,33 +422,6 @@ class WMTOperationsImpl<T: WMTUserOperation>: WMTOperations, WMTService {
             self.lastFetchResult = result
             completion(result)
         }
-    }
-    
-    private func processServerTime(response: WMTOperationListResponse<T>, requestStarted: Date) {
-        
-        let now = Date()
-        let requestDelay = now.timeIntervalSince1970 - requestStarted.timeIntervalSince1970
-        
-        // server does not support this feature
-        guard var serverTime = response.currentTimestamp else {
-            return
-        }
-        
-        // Reject the value if the request took too long and we already have a server date.
-        // This is to avoid volatility of the value
-        if currentServerDate != nil && requestDelay > 1 {
-            return
-        }
-        
-        // We're adding half of the time that the request took to compensate for the network delay
-        serverTime = serverTime.addingTimeInterval(requestDelay/2)
-        
-        // If the difference is under 0.3 seconds, we ignore the new value to avoid unnecesary changes that might be due to network delay.
-        if let currentServerDate, abs(currentServerDate.timeIntervalSince1970 - serverTime.timeIntervalSince1970) < 0.3 {
-            return
-        }
-        
-        serverDateShiftInSeconds = serverTime.timeIntervalSince1970 - now.timeIntervalSince1970
     }
     
     /// If request for operation fails at known error code, then this private function adjusts description of given AuthError.

--- a/WultraMobileTokenSDK/Operations/WMTOperations.swift
+++ b/WultraMobileTokenSDK/Operations/WMTOperations.swift
@@ -39,18 +39,6 @@ public protocol WMTOperations: AnyObject {
     /// Last cached operation result for easy access.
     var lastFetchResult: GetOperationsResult? { get }
     
-    /// Current server date
-    ///
-    /// This is calculated property based on the difference between phone date
-    /// and date on the server.
-    ///
-    /// This property is available after the first successful operation list request.
-    /// It might be nil if the server doesn't provide such a feature.
-    ///
-    /// Note that this value might be incorrent when the user decide to
-    /// change the system time during the runtime of the application.
-    var currentServerDate: Date? { get }
-    
     /// If operation loading is currently in progress.
     var isLoadingOperations: Bool { get }
     

--- a/WultraMobileTokenSDKTests/IntegrationTests.swift
+++ b/WultraMobileTokenSDKTests/IntegrationTests.swift
@@ -171,24 +171,16 @@ class IntegrationTests: XCTestCase {
         waitForExpectations(timeout: 20, handler: nil)
     }
     
-    /// `currentServerDate` is nil by default and after ops fetch, it should be set
+    /// `currentServerDate` was removed from WMTOperations in favor of more precise powerAuth timeService
     func testCurrentServerDate() {
-        let exp = expectation(description: "Server date should be set after operation fetch")
+        var synchronizedServerDate: Date? = nil
         
-        XCTAssertNil(self.ops.currentServerDate)
-        
-        _ = ops.getOperations { result in
-            
-            switch result {
-            case .success:
-                XCTAssertNotNil(self.ops.currentServerDate)
-            case .failure(let err):
-                XCTFail(err.description)
-            }
-            exp.fulfill()
+        let timeService = pa.timeSynchronizationService
+        if timeService.isTimeSynchronized {
+            synchronizedServerDate = Date(timeIntervalSince1970: timeService.currentTime())
         }
         
-        waitForExpectations(timeout: 20, handler: nil)
+        XCTAssertNotNil(synchronizedServerDate)
     }
     
     /// Test of Login operation approval (1FA)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.10.0
 
-- Removed `currentServerTime` method [(#148)](https://github.com/wultra/mtoken-sdk-android/pull/139)
+- Removed `currentServerTime` property [(#148)](https://github.com/wultra/mtoken-sdk-android/pull/139)
 
 ## 1.9.0 (Jan 24, 2024)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.0
+
+- Removed `currentServerTime` method [(#148)](https://github.com/wultra/mtoken-sdk-android/pull/139)
+
 ## 1.9.0 (Jan 24, 2024)
 
 - Added possibility for custom reject reason [(#143)](https://github.com/wultra/mtoken-sdk-ios/pull/143)

--- a/docs/Migration-1.10.md
+++ b/docs/Migration-1.10.md
@@ -1,0 +1,34 @@
+# Migration from 1.9.x to 1.10.x
+
+This guide contains instructions for migration from Wultra Mobile Token SDK for iOS version `1.9.x` to version `1.10.x`.
+
+## Current Server Date
+
+### Removed Functionality
+
+The following calculated property was removed from the `WMTOperations` protocol:
+
+```swift
+var currentServerDate: Date? { get }
+```
+
+The `currentServerDate` is a calculated property based on the difference between the phone's date and the date on the server. However, it had limitations and could be incorrect under certain circumstances, such as when the user decided to change the system time during the runtime of the application.
+
+### Replace with
+
+The new time synchronization directly from `PowerAuthSDK.timeSynchronizationService` is more precise and reliable. 
+
+Here is the updated test method for reference:
+
+```swift
+/// `currentServerDate` was removed from WMTOperations in favor of more precise powerAuth timeService
+func testCurrentServerDate() {
+    var synchronizedServerDate: Date? = nil
+    let timeService = pa.timeSynchronizationService
+    if timeService.isTimeSynchronized {
+        synchronizedServerDate = Date(timeIntervalSince1970: timeService.currentTime())
+    }
+        
+    XCTAssertNotNil(synchronizedServerDate)
+}
+```

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -15,6 +15,12 @@ Remarks:
 - This library does not contain any UI.
 - We also provide an [Android version of this library](https://github.com/wultra/mtoken-sdk-android). 
 
+## Migration Guides
+
+If you need to upgrade the Wultra Mobile Token SDK for iOS to a newer version, you can check the following migration guides:
+
+- [Migration from version `1.9.x` to `1.10.x`](Migration-1.10.md)
+
 <!-- begin remove -->
 ## Integration Tutorials
 - [SDK Integration](SDK-Integration.md)

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -63,6 +63,7 @@ Note: If you want to use only operations, you can omit the Push dependency and i
 | `1.7.x` | `1.7.x` |
 | `1.8.x` | `1.8.x` |
 | `1.9.x` | `1.8.x` |
+| `1.10.x` | `1.8.x` |
 
 ## Xcode Compatibility
 


### PR DESCRIPTION
#123 
Removed `currentServerDate` from `WMTOperations` and replace with powerAuthSDK timeService where needed