### PR TITLE
Fix typos in deeplink docs in URI scheme

### DIFF
--- a/docs/Using-Operations-Service.md
+++ b/docs/Using-Operations-Service.md
@@ -717,7 +717,7 @@ public struct WMTPACData: Decodable {
 ```
 
 - two methods are provided:
-    - `parseDeeplink(url: URL) -> WMTPACData?` - URI is expected to be in the format `"scheme://code=$JWT"` or `scheme://operation?oid=5b753d0d-d59a-49b7-bec4-eae258566dbb&potp=12345678}`
+    - `parseDeeplink(url: URL) -> WMTPACData?` - URI is expected to be in the format `scheme://code=$JWT` or `scheme://operation?oid=5b753d0d-d59a-49b7-bec4-eae258566dbb&potp=12345678`
     - `parseQRCode(code: String) -> WMTPACData?` - code is to be expected in the same format as deeplink formats or as a plain JWT
     - mentioned JWT should be in the format `{“typ”:”JWT”, “alg”:”none”}.{“oid”:”5b753d0d-d59a-49b7-bec4-eae258566dbb”, “potp”:”12345678”} `
   


### PR DESCRIPTION
Fixes: #153 