### PR TITLE
add warning for non-empty Alert title attribute

### DIFF
--- a/WultraMobileTokenSDK/Operations/Model/UserOperation/Attributes/WMTOperationAttributeAlert.swift
+++ b/WultraMobileTokenSDK/Operations/Model/UserOperation/Attributes/WMTOperationAttributeAlert.swift
@@ -56,5 +56,9 @@ public class WMTOperationAttributeAlert: WMTOperationAttribute {
         self.message = try c.decode(String.self, forKey: .message)
         
         try super.init(from: decoder)
+        
+        if !self.label.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            D.warning("The title should be an empty string, since a specific alert title is used as the cell header.")
+        }
     }
 }


### PR DESCRIPTION
As discussed, we want to put warning for cases when generic title is in payload. 
In case of operation Alert types, we have alert specific optional field.