### PR TITLE
Improve logging around preApproval screens

### DIFF
--- a/WultraMobileTokenSDK/Operations/Model/UserOperation/WMTOperationUIData.swift
+++ b/WultraMobileTokenSDK/Operations/Model/UserOperation/WMTOperationUIData.swift
@@ -47,8 +47,40 @@ open class WMTOperationUIData: Decodable {
         let c = try decoder.container(keyedBy: Keys.self)
         flipButtons = try? c.decode(Bool.self, forKey: .flipButtons)
         blockApprovalOnCall = try? c.decode(Bool.self, forKey: .blockApprovalOnCall)
-        preApprovalScreens = (try? c.decode([WMTPreApprovalScreen].self, forKey: .preApprovalScreens)) // plural
-            ?? WMTPreApprovalScreen.fromLegacy(try? c.superDecoder(forKey: .preApprovalScreenLegacy)) // singular fallback else nil
+        
+        if c.contains(.preApprovalScreens) {
+            // New format: "preApprovalScreens" (plural, array)
+            D.debug("Decoding preApprovalScreens.")
+            var decoded: [WMTPreApprovalScreen] = []
+            do {
+                var container = try c.nestedUnkeyedContainer(forKey: .preApprovalScreens)
+                while !container.isAtEnd {
+                    do {
+                        let screen = try container.decode(WMTPreApprovalScreen.self)
+                        decoded.append(screen)
+                    } catch {
+                        D.error("Skipping invalid WMTPreApprovalScreen: \(error)")
+                    }
+                }
+            } catch {
+                D.error("Failed to decode preApprovalScreens container: \(error)")
+            }
+            if c.contains(.preApprovalScreenLegacy) {
+                D.info("Payload contains both 'preApprovalScreens' and legacy 'preApprovalScreen' — legacy is ignored.")
+            }
+            preApprovalScreens = decoded.isEmpty ? nil : decoded
+        } else if c.contains(.preApprovalScreenLegacy) {
+            // Legacy format: "preApprovalScreen" (singular object)
+            D.debug("Decoding preApprovalScreen (legacy format).")
+            let screens = WMTPreApprovalScreen.fromLegacy(try? c.superDecoder(forKey: .preApprovalScreenLegacy))
+            if screens == nil {
+                D.error("Failed to decode preApprovalScreen (legacy format).")
+            }
+            preApprovalScreens = screens
+        } else {
+            preApprovalScreens = nil
+        }
+        
         postApprovalScreen = try? c.decode(WMTPostApprovalScreenDecodable.self, forKey: .postApprovalScreen).postApprovalObject
     }
     

--- a/WultraMobileTokenSDK/Operations/Model/UserOperation/WMTOperationUIData.swift
+++ b/WultraMobileTokenSDK/Operations/Model/UserOperation/WMTOperationUIData.swift
@@ -56,7 +56,7 @@ open class WMTOperationUIData: Decodable {
                 var container = try c.nestedUnkeyedContainer(forKey: .preApprovalScreens)
                 while !container.isAtEnd {
                     do {
-                        let screen = try container.decode(WMTPreApprovalScreen.self)
+                        let screen = try WMTPreApprovalScreen(from: container.superDecoder())
                         decoded.append(screen)
                     } catch {
                         D.error("Skipping invalid WMTPreApprovalScreen: \(error)")

--- a/WultraMobileTokenSDKTests/OperationUIDataTests.swift
+++ b/WultraMobileTokenSDKTests/OperationUIDataTests.swift
@@ -374,6 +374,84 @@ struct OperationUIDataTests {
         #expect(first?.elements == nil) // empty items → nil
     }
     
+    @Test
+    func testPreApprovalScreenMissingHeadingAndMessage() {
+        let json = """
+        {
+          "id":"1","name":"n","data":"d","status":"PENDING",
+          "operationCreated":"2023-04-25T13:09:52+0000",
+          "operationExpires":"2023-04-25T13:14:52+0000",
+          "ui":{
+            "preApprovalScreens":[{
+              "type":"WARNING"
+            }]
+          },
+          "allowedSignatureType":{"type":"2FA","variants":[]},
+          "formData":{"title":"t","message":"m","attributes":[]}
+        }
+        """
+        let result = prepareResult(response: json)
+        // Screen decode should fail — heading and message are required
+        #expect(result?.ui?.preApprovalScreens == nil)
+    }
+    
+    @Test
+    func testPreApprovalScreenWithHeadingAndMessage() {
+        let json = """
+        {
+          "id":"1","name":"n","data":"d","status":"PENDING",
+          "operationCreated":"2023-04-25T13:09:52+0000",
+          "operationExpires":"2023-04-25T13:14:52+0000",
+          "ui":{
+            "preApprovalScreens":[{
+              "type":"INFO",
+              "heading":"Test Heading",
+              "message":"Test Message"
+            }]
+          },
+          "allowedSignatureType":{"type":"2FA","variants":[]},
+          "formData":{"title":"t","message":"m","attributes":[]}
+        }
+        """
+        guard let result = prepareResult(response: json) else {
+            Issue.record("Failed to parse JSON data"); return
+        }
+        let screen = result.ui?.preApprovalScreens?.first
+        #expect(screen != nil)
+        #expect(screen?.type == .info)
+        #expect(screen?.heading == "Test Heading")
+        #expect(screen?.message == "Test Message")
+    }
+    
+    @Test
+    func testPreApprovalScreensArraySkipsInvalidKeepsValid() {
+        let json = """
+        {
+          "id":"1","name":"n","data":"d","status":"PENDING",
+          "operationCreated":"2023-04-25T13:09:52+0000",
+          "operationExpires":"2023-04-25T13:14:52+0000",
+          "ui":{
+            "preApprovalScreens":[
+              {"type":"INFO","heading":"First","message":"First message"},
+              {"type":"WARNING"},
+              {"type":"INFO","heading":"Third","message":"Third message"}
+            ]
+          },
+          "allowedSignatureType":{"type":"2FA","variants":[]},
+          "formData":{"title":"t","message":"m","attributes":[]}
+        }
+        """
+        guard let result = prepareResult(response: json) else {
+            Issue.record("Failed to parse JSON data"); return
+        }
+        let screens = result.ui?.preApprovalScreens
+        #expect(screens?.count == 2)
+        #expect(screens?[0].heading == "First")
+        #expect(screens?[0].message == "First message")
+        #expect(screens?[1].heading == "Third")
+        #expect(screens?[1].message == "Third message")
+    }
+    
     // MARK: Helpers
     private func prepareResult(response: String) -> WMTUserOperation? {
         let result = try? jsonDecoder.decode(WMTUserOperation.self, from: response.data(using: .utf8)!)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -16,6 +16,7 @@
     - Added `WMTQROperation.verifySignature(for:)` convenience method that verifies the signature using the proper PowerAuth key based on `keyType`.
     - Added `PowerAuthSDK.verifyDigitalSignature(of:)` extension for verifying a `WMTQROperation` directly from a `PowerAuthSDK` instance.
     - `WMTQROperationParser` can now accept an optional `PowerAuthSDK` instance via `init(powerAuth:)` to automatically verify the operation signature during parsing. Invalid signatures produce the new `signatureVerificationFailed` error.
+- Improved `PreApprovalScreen` decoding & logging [(#226)](https://github.com/wultra/mtoken-sdk-ios/issues/226).
 - See [Migration from version `2.4.x` to `3.0.x`](Migration-3.0.md) for details.
 
 ## 2.4.0


### PR DESCRIPTION
#226 

When pre-approval screen decoding failed, errors were silently swallowed. The code tried the new format (preApprovalScreens), and on failure silently fell through to legacy (preApprovalScreen) — producing confusing legacy-path error logs when the real issue was in the new format. Additionally, if one screen in an array was malformed, the entire array was lost.